### PR TITLE
Allow to add arbitrary metadata for features

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,24 @@ class ChatController < ApplicationController
 end
 ```
 
+### Metadata
+
+You can add arbitrary metadata to features:
+
+```ruby
+feature :manual_quantity_backsync, icon: :updated, description: "Manual quantity sync for imported products" do |user: nil|
+  !!user&.features&.fetch("manual_quantity_backsync", false)
+end
+```
+
+That metadata can be later programmatically accessed and exposed into admin panels, API documentation, etc.
+
+```ruby
+Rails.features.first.metadata
+# => { icon: :updated, description: "Manual quantity sync for imported products" }
+```
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/feature_toggles/feature.rb
+++ b/lib/feature_toggles/feature.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FeatureToggles
   class Feature
     def initialize(name, resolver, **metadata)

--- a/lib/feature_toggles/feature.rb
+++ b/lib/feature_toggles/feature.rb
@@ -1,0 +1,15 @@
+module FeatureToggles
+  class Feature
+    def initialize(name, resolver, **metadata)
+      @name     = name
+      @resolver = resolver
+      @metadata = metadata
+    end
+
+    attr_reader :name, :resolver, :metadata
+
+    def [](key)
+      @metadata[key]
+    end
+  end
+end

--- a/spec/lib/feature_toggles/feature_spec.rb
+++ b/spec/lib/feature_toggles/feature_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe FeatureToggles::Feature do
+  subject { described_class.new(name, resolver, metadata) }
+
+  let(:name)     { "some-feature" }
+  let(:metadata) { {foo: :bar, baz: nil} }
+  let(:resolver) { proc { true } }
+
+  describe "#name" do
+    it { expect(subject.name).to eq(name) }
+  end
+
+  describe "#resolver" do
+    it { expect(subject.resolver).to eq(resolver) }
+  end
+
+  describe "#metadata" do
+    it { expect(subject.metadata).to eq(metadata) }
+  end
+
+  describe "#[]" do
+    it "returns metadata value by key" do
+      expect(subject[:foo]).to eq(:bar)
+      expect(subject[:baz]).to be_nil
+    end
+  end
+end

--- a/spec/lib/feature_toggles/mechatronic_spec.rb
+++ b/spec/lib/feature_toggles/mechatronic_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe FeatureToggles::Mechatronic do
 
       it { expect { subject.feature(:foo) { false } }.to raise_error(ArgumentError) }
     end
+
+    context "with provided metadata" do
+      before { subject.feature(:foo, icon: :download) { true } }
+
+      it "saves it into the feature" do
+        expect(subject.first.metadata).to eq(icon: :download)
+      end
+    end
   end
 
   describe "#enabled?" do
@@ -75,6 +83,24 @@ RSpec.describe FeatureToggles::Mechatronic do
         expect(subject.enabled?(:x)).to eq true
         expect(subject.enabled?(:y)).to eq false
       end
+    end
+  end
+
+  describe "#each" do
+    subject do
+      described_class.new do
+        feature(:x) { false }
+        feature(:y) { true }
+      end
+    end
+
+    context "without block" do
+      it { expect(subject.each).to be_an(Enumerator) }
+      it { expect(subject.each.first).to be_an(FeatureToggles::Feature) }
+    end
+
+    context "with block" do
+      it { expect(subject.map(&:name)).to eq(%i[x y]) }
     end
   end
 


### PR DESCRIPTION
Sometimes it would be nice to attach some additional information to feature declaration that can be programmatically exposed in admin panel, GraphQL API documentation, etc, etc.

Something like this:
```ruby
# config/features.rb
feature :manual_quantity_backsync, icon: :updated, description: "Manual quantity sync for imported products" do |user: nil|
  !!user&.features&.fetch("manual_quantity_backsync", true)
end
```

Provided icon name can be then used to create beautiful and compact feature toggles in an admin panel and description can be used as a tooltip for these toggles.

What do you think?  