### PR TITLE
Make sure paths are not duplicated for Rails

### DIFF
--- a/lib/feature_toggles/railtie.rb
+++ b/lib/feature_toggles/railtie.rb
@@ -26,7 +26,7 @@ module FeatureToggles
       file = ::Rails.root.join("config", "features.rb")
       paths << file.to_s if file.exist?
 
-      Rails.application.config.features = FeatureToggles.build(paths)
+      Rails.application.config.features = FeatureToggles.build(paths.uniq)
     end
   end
 end

--- a/lib/feature_toggles/version.rb
+++ b/lib/feature_toggles/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FeatureToggles
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
# Context

`Rails.application.railties` includes `Rails.root` folder, so it ends with evaluating the same `config/features.rb` file twice. This behavior was only met on Rails 6.1.4.4, Ruby 3.0.3. On a project with Rails 6.0.4.4 and Ruby 2.7.3 it doesn't evaluate the file twice.

Anyway applying `.uniq` here fixes the problem and doesn't change the current behavior.

# What's inside

- Added a `.uniq` to the paths for Rails loading logic
- Bumped a patch version by 1